### PR TITLE
fixes #11: Changed light test cycle time to 0.75 seconds

### DIFF
--- a/pin/service/lamps_single_test.py
+++ b/pin/service/lamps_single_test.py
@@ -37,7 +37,7 @@ class Mode(Handler):
         compare = lambda x, y: cmp(x.label, y.label)
         lamps = sorted(p.lamps.values(), cmp=compare)
         self.devices = util.Cycle(lamps)
-        self.interval = 2.0
+        self.interval = 0.75
 
         self.display = ui.Panel(name=self.name)
 


### PR DESCRIPTION
Changed to 0.75 seconds. Commit message is incorrect. 

@charredresistors: Can you check to see if this looks good on the real pinball machine?